### PR TITLE
made slaveSelectPin selectable

### DIFF
--- a/melexis.cpp
+++ b/melexis.cpp
@@ -159,8 +159,9 @@ int16_t axis_Value;
 /******************************************************************************
  * Constructors
  ******************************************************************************/
-MELEXIS::MELEXIS()
+MELEXIS::MELEXIS(uint8_t selectPin)
 {	
+	slaveSelectPin = selectPin;
 	pinMode (slaveSelectPin, OUTPUT);
 	digitalWrite(slaveSelectPin,HIGH); 
 	SPI.begin();

--- a/melexis.h
+++ b/melexis.h
@@ -35,7 +35,7 @@ class MELEXIS
 		uint16_t get_eeprom_word(uint16_t addr, uint8_t offset, uint8_t length);
 		uint16_t get_EE_Key(uint16_t addr);
 
-		MELEXIS();
+		MELEXIS(uint8_t selectPin);
 	
 	private:
 		bool do_checksum(uint8_t* message);

--- a/test/test.pde
+++ b/test/test.pde
@@ -17,7 +17,7 @@
 
 #include "D:\devstuff\melexis_interface\melexis.cpp"
 
-MELEXIS test;
+MELEXIS test(15);
 
 
 void setup()


### PR DESCRIPTION
The slaveSelectPin was locked to 20. This prevents getting information from muliple sensors, or situations where 20 may be used for something else.

This makes the slaveSelectPin chosen at instantiation.
